### PR TITLE
Ideal Functionality @ payment

### DIFF
--- a/src/payment/f_contract.py
+++ b/src/payment/f_contract.py
@@ -64,7 +64,7 @@ class Contract(UCWrappedFunctionality):
         _sig = data['sig']
 
         assert self.flag == 'CHALLANGE'
-        for p in self.n:
+        for p in range(self.n):
             assert self._check_sig(p, _sig[p], _state)
 
         assert _state['nonce'] >= self.nonce
@@ -89,7 +89,7 @@ class Contract(UCWrappedFunctionality):
             m = wait_for(self.channels['w2f']).msg
             assert m == ('OK',)
 
-            leaked_msg = ('pay', (_from, _to, _amt))
+            leaked_msg = ('challenge', (_from, _state, _sig))
             self.leak(leaked_msg, 0)
 
 

--- a/src/payment/f_contract.py
+++ b/src/payment/f_contract.py
@@ -1,0 +1,73 @@
+from itm import UCWrappedFunctionality
+from utils import wait_for
+import logging
+log = logging.getLogger(__name__)
+
+class Contract(UCWrappedFunctionality):
+    def __init__(self, k, bits, sid, pid, channels, pump, poly, importargs):
+        self.ssid = sid[0]
+        self.round = sid[1]
+        self.delta = sid[2]
+        UCWrappedFunctionality.__init__(self, k, bits, sid, pid, channels, poly, pump, importargs)
+
+        self.on_chain_channel_id = 0 # not sure if it's the correct format
+        self.on_chain_channel_id = 1 # not sure if it's the correct format
+
+        self.settlement = self.delta * 2 # the challenge period
+        self.deadline = 0
+        self.nonce = 0
+        self.balances = [0] * self.n
+        self.flag = 'NORMAL'    # {'NORMAL', 'CHALLANGE'}
+                                # 'NORMAL': all are honest
+                                # 'CHALLANGE': enter into challenge period
+
+
+    def __send2p(self, i, msg, imp):
+        self.write('f2p', (i, msg), imp)
+
+    def send2w(self, i, func, args, delta, imp):
+        codeblock = (
+            'schedule', 
+            func, 
+            args, 
+            delta
+        )
+        self.write('f2w', codeblock, imp)
+        m = wait_for(self.channels['w2f']).msg
+        assert m == ('OK',)
+
+    # p2f handler
+    def party_msg(self, msg):
+        log.debug('Contract/Receive msg from P in real world: {}'.format(msg))
+        command = msg['msg']
+        tokens = msg['imp']
+        data = msg['data']
+        sender = data['sender']
+        if command == 'pay':
+            # normal offchain payment
+            pass
+        elif command == 'challenge':
+            # entering into challenge, receive challenge from P_{receiver}
+            pass
+        elif command == 'read':
+            pass
+        # === ^ offchain operations === v onchain operations
+        elif command == 'init':
+            pass
+        elif command == 'close':
+            pass
+        elif command == 'deposit':
+            pass
+        elif command == 'withdraw':
+            pass
+        else:
+            self.pump.write("dump")
+
+    def adv_msg(self, d):
+        self.pump.write("dump")
+
+    def env_msg(self, msg):
+        self.pump.write("dump")
+
+    def wrapper_msg(self, msg):
+        self.pump_write("dump")

--- a/src/payment/f_contract.py
+++ b/src/payment/f_contract.py
@@ -107,8 +107,6 @@ class Contract(UCWrappedFunctionality):
             # entering into challenge, receive challenge from P_{receiver}
             self.recv_challenge(data, imp)
         # === ^ offchain operations === v onchain operations
-        elif command == 'read':
-            pass
         elif command == 'init':
             pass
         elif command == 'close':

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -18,10 +18,16 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
         self.n = len(self.parties)
         self.round_upper_bound = 1
         self.delta = sid[2] * self.round_upper_bound
+
         self.balances[self.n] # record all parties' balances
         self.isOpen = False # if there's a payment channel open
+        
         UCWrappedFunctionality.__init__(self, k, bits, sid, pid, channels, poly, pump, importargs)
 
+    '''
+    __func: functions with __ as prefix are actually executed in the wrapper
+    func: normal functions are called in this ideal functionality to schedule __func call in the wrapper
+    '''
     def __deposit(self, _from, _amount):
         self.balances[_from] += _amount
 
@@ -61,10 +67,10 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             )
             self.write('f2w', codeblock)
             m = wait_for(self.channels['w2f']).msg
-            assert m == ('OK',)
+            assert m == ('OK',) # supposed to get this immediately, just to check if the message is successfully queued in wrapper
 
             leaked_msg = 'leaked msg (i don know what is the format of leaked message is look like, so a placeholder here)'
-            self.leak('f2a', leaked_msg, 0)
+            self.leak('f2a', leaked_msg, 0) # leak msg to the adversary because this part simulates the msg being sent to the synchronous channel in the real world
             self.isOpen = True
 
     def close_channel(self, _from):

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -24,6 +24,12 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
     def __withdraw(self, _from, _amount):
         self.balances[_from] -= _amount
 
+    def __read(self):
+        bal = []
+        for i in range(self.n):
+            bal.append(self.balances[i])
+        return bal
+
     def __pay(self, _from, _to, _amount):
         self.balances[_from] -= _amount
         self.balances[_to] += _amount
@@ -92,6 +98,17 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
         self.leak('f2a', leaked_msg, 0)
 
     def read_balance(self, _from):
+        delay = 1 # the next round
+        codeblock = (
+            'schedule'
+            self.__read,
+            (),
+            delay
+        )
+        self.write('f2w', codeblock)
+        m = wait_for(self.channels['w2f']).msg
+        assert m == ('OK',)
+
         amount = self.balances[_from]
         msg = ('read_balance', (_from, amount)) # donna if the format is right
         self.write('f2p', msg)

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -58,7 +58,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
 
     def init_channel(self, _from, amount):
         if not self.isOpen:
-            delay = 0 # some delay of time
+            delay = self.delta # on-chain communication delay
             codeblock = (
                 'schedule'
                 self.__init,
@@ -75,7 +75,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
 
     def close_channel(self, _from):
         if self.isOpen:
-            delay = 0 # some delay of time
+            delay = self.delta # on-chain communication delay
             codeblock = (
                 'schedule'
                 self.__close,
@@ -93,7 +93,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
     def pay(self, _from, _to, amount):
         if not self.isOpen or self.balances[_from] < amount: return
 
-        delay = 0 # some delay of time
+        delay = 1 # delay only 1 round because pay is supposed to be off-chain
         codeblock = (
             'schedule'
             self.__pay,
@@ -109,16 +109,6 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
 
     def read_balance(self, _from):
         if not self.isOpen: return # if there's no channel, cannot read balance
-        delay = 1 # the next round
-        codeblock = (
-            'schedule'
-            self.__read,
-            (),
-            delay
-        )
-        self.write('f2w', codeblock)
-        m = wait_for(self.channels['w2f']).msg
-        assert m == ('OK',)
 
         amount = self.balances[_from]
         msg = ('read_balance', (_from, amount)) # donna if the format is right
@@ -127,7 +117,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
 
     def deposit(self, _from, amount):
         if self.isOpen:
-            delay = 0 # some delay of time
+            delay = self.delta # on-chain communication delay
             codeblock = (
                 'schedule'
                 self.__deposit,
@@ -146,7 +136,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             if amount > self.balances[_from]
                 return
 
-            delay = 0 # some delay of time
+            delay = self.delta # on-chain communication delay
             codeblock = (
                 'schedule'
                 self.__withdraw,

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -34,8 +34,19 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
 
     def init_channel(self, _from, amount):
         if not self.isOpen:
-            self.leak('f2a', ('init', (_from, amount)), 0)
-            self.balances[_from] += amount # TODO: needs delay
+            delay = 0 # some delay of time
+            codeblock = (
+                'schedule'
+                self.__deposit,
+                (_from, amount),
+                delay
+            )
+            self.write('f2w', codeblock)
+            m = wait_for(self.channels['w2f']).msg
+            assert m == ('OK',)
+
+            leaked_msg = 'leaked msg (i don know what is the format of leaked message is look like, so a placeholder here)'
+            self.leak('f2a', leaked_msg, 0)
             self.isOpen = True
 
     def close_channel(self, _from):

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -1,0 +1,74 @@
+from itm import UCWrappedFunctionality, ITM
+from utils import wait_for, waits
+from numpy.polynomial.polynomial import Polynomial
+from comm import ishonest, isdishonest
+import gevent
+import logging
+
+log = logging.getLogger(__name__)
+
+class Syn_Payment_Functionality(UCWrappedFunctionality):
+    def __init__(self, k, bits, sid, pid, channels, pump, poly, importargs):
+        self.ssid = sid[0]
+        self.parties = sid[1]
+        self.n = len(self.parties)
+        self.round_upper_bound = 1
+        self.delta = sid[2] * self.round_upper_bound
+        self.balances[self.n] # record all parties' balances
+        self.isOpen = False # if there's a payment channel open
+        UCWrappedFunctionality.__init__(self, k, bits, sid, pid, channels, poly, pump, importargs)
+
+    def init_channel(self, _from, amount):
+        if not self.isOpen:
+            self.leak('f2a', ('init', (_from, amount)), 0)
+            self.balances[_from] += amount
+            self.isOpen = True
+
+    def close_channel(self, _from):
+        if self.isOpen:
+            self.leak('f2a', ('close', (_from)), 0)
+            self.write('f2w', ('withdrawAll', _from, self.n, self.balances))
+            self.balances = [0] * self.n
+            self.isOpen = False
+
+    def pay(self, _from, _to, amount):
+        if self.balances[_from] < amount:
+            self.write('f2w', ('pay_fail', sender, amount))
+            return
+        self.balances[_from] -=  amount
+        self.balances[_to] += amount
+        self.leak('f2a', ('pay', (_from, _to, amount)), 0)
+
+    def read_balance(self, _from):
+        amount = self.balances[_from]
+        self.write('f2p', ('read_balance', _from, amount))
+        self.leak('f2a', ('read_balance', (_from, amount)), 0)
+
+    def wrapper_msg(self, msg):
+        self.pump.write("dump")
+    def adv_msg(self, msg):
+        self.pump.write("dump")
+    def env_msg(self, msg):
+        self.pump.write("dump")
+
+
+from itm import WrappedPartyWrapper, PartyWrapper
+from adversary import DummyWrappedAdversary
+from syn_ours import Syn_FWrapper
+from execuc import execWrappedUC
+def env1(static, z2p, z2f, z2a, z2w, a2z, p2z, f2z, w2z, pump):
+    n = 2
+    sid = ('one', (1,2), 3)
+    static.write( ('sid', sid) )
+
+    z2p.write( ((sid,1), ('input',1)), n*(4*n + 1) )
+    waits(pump, a2z)#wait_for(a2z)
+
+    z2a.write( ('A2W', ('get-leaks',)) )
+    m = waits(a2z, pump)#wait_for(a2z)
+
+
+if __name__=='__main__':
+    # execWrappedUC(env1, [('F_bracha',Syn_Bracha_Functionality)], WrappedPartyWrapper, Syn_FWrapper, 'F_bracha', RBC_Simulator)
+    pass
+

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -18,6 +18,20 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
         self.isOpen = False # if there's a payment channel open
         UCWrappedFunctionality.__init__(self, k, bits, sid, pid, channels, poly, pump, importargs)
 
+    def __deposit(self, _from, _amount):
+        self.balances[_from] += _amount
+
+    def __withdraw(self, _from, _amount):
+        self.balances[_from] -= _amount
+
+    def __all_withdraw_all(self):
+        for i in range(self.n):
+            __withdraw(i, self.balances[i])
+
+    def __pay(self, _from, _to, _amount):
+        self.balances[_from] -= _amount
+        self.balances[_to] += _amount
+
     def init_channel(self, _from, amount):
         if not self.isOpen:
             self.leak('f2a', ('init', (_from, amount)), 0)
@@ -46,14 +60,25 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
 
     # the handler bound on p2f channel, handling message from parties
     def party_msg(sef, msg):
-        if msg['msg'] == 'init':
-            pass
-        elif msg['msg'] == 'close':
-            pass
-        elif msg['msg'] == 'pay':
-            pass
-        elif msg['msg'] == 'read':
-            pass
+        log.debug('Party message in payment {}'.format(msg))
+        command = msg['msg']
+        tokens = msg['imp']
+        data = msg['data']
+        if command == 'init':
+            sender = data['sender']
+            amount = data['amount']
+            init_channel(sender, amount)
+        elif command == 'close':
+            sender = data['sender']
+            close_channel(sender)
+        elif command == 'pay':
+            sender = data['sender']
+            receiver = data['receiver']
+            amount = data['amount']
+            pay(sender, receiver, amount)
+        elif command == 'read':
+            sender = data['sender']
+            read_balance(sender)
         else:
             self.pump.write("pump")
 

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -75,7 +75,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             assert m == ('OK',) # supposed to get this immediately, just to check if the message is successfully queued in wrapper
 
             leaked_msg = 'leaked msg (i don know what is the format of leaked message is look like, so a placeholder here)'
-            self.leak('f2a', leaked_msg, 0) # leak msg to the adversary because this part simulates the msg being sent to the synchronous channel in the real world
+            self.leak(leaked_msg, 0) # leak msg to the adversary because this part simulates the msg being sent to the synchronous channel in the real world
             self.isOpen = True
 
     def close_channel(self, _from):
@@ -92,7 +92,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             assert m == ('OK',)
 
             leaked_msg = ('close', (_from))
-            self.leak('f2a', leaked_msg, 0)
+            self.leak(leaked_msg, 0)
             self.isOpen = False
 
     def pay(self, _from, _to, amount):
@@ -110,7 +110,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
         assert m == ('OK',)
 
         leaked_msg = ('pay', (_from, _to, amount))
-        self.leak('f2a', leaked_msg, 0)
+        self.leak(leaked_msg, 0)
 
     def read_balance(self, _from):
         if not self.isOpen: return # if there's no channel, cannot read balance
@@ -134,7 +134,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             assert m == ('OK',)
 
             leaked_msg = 'leaked msg (i don know what is the format of leaked message is look like, so a placeholder here)'
-            self.leak('f2a', leaked_msg, 0)
+            self.leak(leaked_msg, 0)
 
     def withdraw(self, _from, amount):
         if self.isOpen:
@@ -150,7 +150,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             assert m == ('OK',)
 
             leaked_msg = 'leaked msg (i don know what is the format of leaked message is look like, so a placeholder here)'
-            self.leak('f2a', leaked_msg, 0)
+            self.leak(leaked_msg, 0)
 
     # p2f channel handler, handling message from parties
     def party_msg(sef, msg):

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -8,6 +8,10 @@ import logging
 log = logging.getLogger(__name__)
 
 class Syn_Payment_Functionality(UCWrappedFunctionality):
+    '''
+    Ideal Functionality of Payment Channel (now only uni-directional)
+    It includes the ideal functionality of on-chain smart contract open/close payment channel + off-chain synchronous communication of signed payloads.
+    '''
     def __init__(self, k, bits, sid, pid, channels, pump, poly, importargs):
         self.ssid = sid[0]
         self.parties = sid[1]
@@ -150,7 +154,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             leaked_msg = 'leaked msg (i don know what is the format of leaked message is look like, so a placeholder here)'
             self.leak('f2a', leaked_msg, 0)
 
-    # the handler bound on p2f channel, handling message from parties
+    # p2f channel handler, handling message from parties
     def party_msg(sef, msg):
         log.debug('Party message in payment {}'.format(msg))
         command = msg['msg']
@@ -180,12 +184,18 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             amount = data['amount']
             withdraw(sender, amount)
         else:
+            log.debug('F_payment/Command not found: {}'.format(command))
             self.pump.write("pump")
 
+    # w2f channel handler, handling message from wrapper
     def wrapper_msg(self, msg):
         self.pump.write("dump")
+
+    # a2f channel handler, handling message from adversary
     def adv_msg(self, msg):
         self.pump.write("dump")
+
+    # e2f channel handler, handling message from environment
     def env_msg(self, msg):
         self.pump.write("dump")
 

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -30,12 +30,15 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
 
     def __init(self, _from, _amount):
         __deposit(_from, _amount)
-        self.write('f2p', 'channel init')
+        for i in range(self.n):
+            msg = (i, 'channel init')
+            self.write('f2p', msg)
 
     def __close(self):
         for i in range(self.n):
             __withdraw(i, self.balances[i])
-        self.write('f2p', 'channel close')
+            msg = (i, 'channel close')
+            self.write('f2p', msg)
 
     def init_channel(self, _from, amount):
         if not self.isOpen:

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -24,20 +24,25 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
     def __withdraw(self, _from, _amount):
         self.balances[_from] -= _amount
 
-    def __all_withdraw_all(self):
-        for i in range(self.n):
-            __withdraw(i, self.balances[i])
-
     def __pay(self, _from, _to, _amount):
         self.balances[_from] -= _amount
         self.balances[_to] += _amount
+
+    def __init(self, _from, _amount):
+        __deposit(_from, _amount)
+        self.write('f2p', 'channel init')
+
+    def __close(self):
+        for i in range(self.n):
+            __withdraw(i, self.balances[i])
+        self.write('f2p', 'channel close')
 
     def init_channel(self, _from, amount):
         if not self.isOpen:
             delay = 0 # some delay of time
             codeblock = (
                 'schedule'
-                self.__deposit,
+                self.__init,
                 (_from, amount),
                 delay
             )
@@ -54,7 +59,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             delay = 0 # some delay of time
             codeblock = (
                 'schedule'
-                self.__all_withdraw_all,
+                self.__close,
                 (),
                 delay
             )

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -110,6 +110,25 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             leaked_msg = 'leaked msg (i don know what is the format of leaked message is look like, so a placeholder here)'
             self.leak('f2a', leaked_msg, 0)
 
+    def withdraw(self, _from, amount):
+        if self.isOpen:
+            if amount > self.balances[_from]
+                return
+
+            delay = 0 # some delay of time
+            codeblock = (
+                'schedule'
+                self.__withdraw,
+                (_from, amount),
+                delay
+            )
+            self.write('f2w', codeblock)
+            m = wait_for(self.channels['w2f']).msg
+            assert m == ('OK',)
+
+            leaked_msg = 'leaked msg (i don know what is the format of leaked message is look like, so a placeholder here)'
+            self.leak('f2a', leaked_msg, 0)
+
     # the handler bound on p2f channel, handling message from parties
     def party_msg(sef, msg):
         log.debug('Party message in payment {}'.format(msg))
@@ -135,6 +154,10 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             sender = data['sender']
             amount = data['amount']
             deposit(sender, amount)
+        elif command == 'withdraw':
+            sender = data['sender']
+            amount = data['amount']
+            withdraw(sender, amount)
         else:
             self.pump.write("pump")
 

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -85,8 +85,9 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
 
     def read_balance(self, _from):
         amount = self.balances[_from]
-        self.write('f2p', ('read_balance', _from, amount))
-        # self.leak('f2a', ('read_balance', (_from, amount)), 0) -> no need to leak to adversary, pointless
+        msg = ('read_balance', (_from, amount)) # donna if the format is right
+        self.write('f2p', msg)
+        # no need to leak to adversary, pointless
 
     # the handler bound on p2f channel, handling message from parties
     def party_msg(sef, msg):

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -51,9 +51,19 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
 
     def close_channel(self, _from):
         if self.isOpen:
-            self.leak('f2a', ('close', (_from)), 0)
-            self.write('f2w', ('schedule', withdraw(), (_from, self.n, self.balances), delay)) # write a codeblock to wrapper, asking wrapper to schedule this codeblock (for now, all codeblocks are executed in wrapper)
-            self.balances = [0] * self.n # move this to an action that should be done in wrapper
+            delay = 0 # some delay of time
+            codeblock = (
+                'schedule'
+                self.__all_withdraw_all,
+                (),
+                delay
+            )
+            self.write('f2w', codeblock)
+            m = wait_for(self.channels['w2f']).msg
+            assert m == ('OK',)
+
+            leaked_msg = ('close', (_from))
+            self.leak('f2a', leaked_msg, 0)
             self.isOpen = False
 
     def pay(self, _from, _to, amount):

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -81,7 +81,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
             self.isOpen = False
 
     def pay(self, _from, _to, amount):
-        if self.balances[_from] < amount: return
+        if not self.isOpen or self.balances[_from] < amount: return
 
         delay = 0 # some delay of time
         codeblock = (
@@ -98,6 +98,7 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
         self.leak('f2a', leaked_msg, 0)
 
     def read_balance(self, _from):
+        if not self.isOpen: return # if there's no channel, cannot read balance
         delay = 1 # the next round
         codeblock = (
             'schedule'

--- a/src/payment/f_payment.py
+++ b/src/payment/f_payment.py
@@ -94,6 +94,22 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
         self.write('f2p', msg)
         # no need to leak to adversary, pointless
 
+    def deposit(self, _from, amount):
+        if self.isOpen:
+            delay = 0 # some delay of time
+            codeblock = (
+                'schedule'
+                self.__deposit,
+                (_from, amount),
+                delay
+            )
+            self.write('f2w', codeblock)
+            m = wait_for(self.channels['w2f']).msg
+            assert m == ('OK',)
+
+            leaked_msg = 'leaked msg (i don know what is the format of leaked message is look like, so a placeholder here)'
+            self.leak('f2a', leaked_msg, 0)
+
     # the handler bound on p2f channel, handling message from parties
     def party_msg(sef, msg):
         log.debug('Party message in payment {}'.format(msg))
@@ -115,6 +131,10 @@ class Syn_Payment_Functionality(UCWrappedFunctionality):
         elif command == 'read':
             sender = data['sender']
             read_balance(sender)
+        elif command == 'deposit':
+            sender = data['sender']
+            amount = data['amount']
+            deposit(sender, amount)
         else:
             self.pump.write("pump")
 

--- a/src/payment/prot_payment.py
+++ b/src/payment/prot_payment.py
@@ -45,8 +45,11 @@ class Syn_Payment_Protocol(UCWrappedProtocol):
     def react_challenge(self):
         pass
 
-    def get_onchain_block(self):
-        pass
+    def recv_init_channel(self, data):
+        s = data['sender']
+        a = data['amount']
+        self.balances[s] += amount
+        self.isOpen = True
 
     # functionality handler
     # receive msg from the smart contract ideal functionality in the real world
@@ -62,9 +65,9 @@ class Syn_Payment_Protocol(UCWrappedProtocol):
         elif command == 'challenge':
             # entering into challenge
             pass
-        elif command == 'broadcast':
-            # get onchain broadcast (like a mining block notification)
-            pass
+        elif command == 'init_channel':
+            # get onchain notification of channel initialization
+            self.recv_init_channel(data)
         else:
             self.pump.write("dump")
 
@@ -75,6 +78,21 @@ class Syn_Payment_Protocol(UCWrappedProtocol):
     # adv handler
     def adv_msg(self, msg):
         self.pump.write("dump")
+
+
+    def init_channel(self, _from, imp):
+        if self.isOpen: return # if a channel is already open, then fail
+
+        msg = {
+            'msg': 'init',
+            'imp': imp,
+            'data': {
+                'sender': _from,
+                'amount': amount
+            }
+        }
+        self.write('p2f', msg)
+
 
     def pay(self, _from, _to, amount, imp):
         if not self.isOpen: return # if there's no channel, cannot pay offchain
@@ -116,7 +134,9 @@ class Syn_Payment_Protocol(UCWrappedProtocol):
             self.write('p2z', self.balances[self.id])
         elif command == 'init':
             # Z tells P_i to init a channel
-            pass
+            sender = data['sender']
+            amount = data['amount']
+            init_channel(sender, amount, tokens)
         elif command == 'close':
             # Z tells P_i to close a channel
             pass

--- a/src/payment/prot_payment.py
+++ b/src/payment/prot_payment.py
@@ -140,12 +140,12 @@ class Syn_Payment_Protocol(UCWrappedProtocol):
         elif command == 'close':
             # Z tells P_i to close a channel
             pass
-        elif command == 'deposit':
-            # Z tells P_i to init a channel
-            pass
-        elif command == 'withdraw':
-            # Z tells P_i to close a channel
-            pass
+        # elif command == 'deposit':
+        #     # Z tells P_i to init a channel
+        #     pass
+        # elif command == 'withdraw':
+        #     # Z tells P_i to close a channel
+        #     pass
         else:
             self.pump.write("dump")
             return

--- a/src/payment/prot_payment.py
+++ b/src/payment/prot_payment.py
@@ -42,8 +42,24 @@ class Syn_Payment_Protocol(UCWrappedProtocol):
         self.balances[s] -= a
         assert self.balances == data['state']
 
-    def react_challenge(self):
-        pass
+    def react_challenge(self, data, imp):
+        _s = data['state']
+        _n = _s[0] # nonce of the state
+        _b = _s[1] # balances of the state
+        # basically P_recv doesnt need to check anything
+        # just send the latest state to challenge is fine
+
+        msg = {
+            'msg': 'challenge',
+            'imp': imp,
+            'data': {
+                'sender': self.id,
+                'nonce': self.nonce-1,
+                'states': self.states[self.nonce-1]
+            }
+        }
+        self.write('p2f', msg)
+
 
     def recv_close_channel(self, data):
         self.nonce = 0
@@ -71,7 +87,7 @@ class Syn_Payment_Protocol(UCWrappedProtocol):
             self.normal_offchain_payment(data)
         elif command == 'challenge':
             # entering into challenge
-            pass
+            self.react_challenge(data, tokens)
         elif command == 'init_channel':
             # get onchain notification of channel initialization
             self.recv_init_channel(data)

--- a/src/payment/prot_payment.py
+++ b/src/payment/prot_payment.py
@@ -30,7 +30,7 @@ class Syn_Payment_Protocol(UCWrappedProtocol):
 
     def normal_offchain_payment(self, data):
         nonce = data['nonce']
-        assert nonce == self.nonce + 1
+        assert nonce == self.nonce
         self.states[nonce] = data['state']
         self.nonce += 1
 
@@ -38,9 +38,9 @@ class Syn_Payment_Protocol(UCWrappedProtocol):
         r = data['receiver']
         a = data['amount']
         assert r == self.id
+        assert a <= self.balances[s]
         self.balances[r] += a
         self.balances[s] -= a
-        assert self.balances == data['state']
 
     def react_challenge(self, data, imp):
         _s = data['state']

--- a/src/payment/prot_payment.py
+++ b/src/payment/prot_payment.py
@@ -1,0 +1,129 @@
+from itm import UCWrappedProtocol, MSG
+from payment import Syn_Channel
+from math import ceil, floor
+from utils import wait_for, waits
+from collections import defaultdict
+from numpy.polynomial.polynomial import Polynomial
+import logging
+
+log = logging.getLogger(__name__)
+
+class Syn_Payment_Protocol(UCWrappedProtocol):
+    #def __init__(self, sid, pid, channels):
+    def __init__(self, k, bits, sid, pid, channels, pump, poly, importargs):
+        self.ssid = sid[0]
+        self.parties = sid[1]
+        self.delta = sid[2]
+        self.n = len(self.parties)
+        self.t = floor(self.n/3)
+        UCWrappedProtocol.__init__(self, k, bits, sid, pid, channels, poly, pump, importargs)
+
+        self.nonce = 0
+        self.balances = [0] * self.n
+        self.isOpen = False
+        self.flag = 'NORMAL'    # {'NORMAL', 'CHALLANGE'}
+                                # 'NORMAL': all are honest
+                                # 'CHALLANGE': enter into challenge period
+
+
+    def _pay_offchain(self):
+        pass
+
+    def _pay_onchain(self):
+        pass
+
+    def normal_offchain_payment(self):
+        pass
+
+    def react_challenge(self):
+        pass
+
+    def get_onchain_block(self):
+        pass
+
+    # functionality handler
+    # receive msg from the smart contract ideal functionality in the real world
+    # b/c it's in a hybrid model
+    def func_msg(self, msg):
+        log.debug('Protocol/Receive msg from F in real world: {}'.format(msg))
+        command = msg['msg']
+        tokens = msg['imp']
+        data = msg['data']
+        if command == 'pay':
+            # normal offchain payment
+            pass
+        elif command == 'challenge':
+            # entering into challenge
+            pass
+        elif command == 'broadcast':
+            # get onchain broadcast (like a mining block notification)
+            pass
+        else:
+            self.pump.write("dump")
+
+    # wrapper handler
+    def wrapper_msg(self, msg):
+        self.pump.write("dump")
+
+    # adv handler
+    def adv_msg(self, msg):
+        self.pump.write("dump")
+
+    # env handler
+    def env_msg(self, msg):
+        log.debug('Env/Receive message from Z in real world: {}'.format(msg))
+        command = msg['msg']
+        tokens = msg['imp']
+        data = msg['data']
+        if command == 'pay':
+            # Z tells P_i to pay another P_j
+            pass
+        elif command == 'read':
+            # Z tells P_i to read its own balance
+            pass
+        elif command == 'init':
+            # Z tells P_i to init a channel
+            pass
+        elif command == 'close':
+            # Z tells P_i to close a channel
+            pass
+        elif command == 'deposit':
+            # Z tells P_i to init a channel
+            pass
+        elif command == 'withdraw':
+            # Z tells P_i to close a channel
+            pass
+        else:
+            self.pump.write("dump")
+            return
+        self.write('p2z', 'OK')
+
+
+from itm import ProtocolWrapper, WrappedProtocolWrapper
+from adversary import DummyWrappedAdversary
+from syn_ours import Syn_FWrapper, Syn_Channel
+from execuc import execWrappedUC
+from utils import z_get_leaks
+
+def env1(static, z2p, z2f, z2a, z2w, a2z, p2z, f2z, w2z, pump):
+    delta = 3
+    n = 3
+    #sid = ('one', (1,2,3), delta)
+    sid = ('one', tuple(range(1,n+1)), delta)
+    static.write( ('sid', sid) )
+
+    z2p.write( ((sid,1), ('input', 2)), n*(4*n + 1) )
+    #wait_for(p2z)
+    waits(pump, p2z)
+
+    def channel_id(fro, to, r):
+        s = ('one', (sid,fro), (sid,to), r, delta)
+        return (s,'F_chan')
+
+    z2a.write( ('A2W', ('get-leaks',)) )
+    msgs = waits(pump, a2z)
+    print('\033[91m [Leaks] \033[0m', '\n'.join(str(m) for m in msgs.msg))
+
+
+if __name__ == '__main__':
+    execWrappedUC(env1, [('F_chan',Syn_Channel)], WrappedProtocolWrapper, Syn_FWrapper, Syn_Bracha_Protocol, DummyWrappedAdversary)


### PR DESCRIPTION
Ideal functionality of payment channel. Basically the following actions.
`init`: init a channel (on-chain tx)
`close`: close a channel (on-chain tx)
`deposit`: deposit money to the channel (on-chain tx)
`withdraw`: withdraw money from the channel (on-chain tx)
`pay`: pay from a party to another party (off-chain tx)
`read`: read the current balance (on-chain tx, but should be done in the next round cuz there's no mining in view function)